### PR TITLE
Github actions configuration

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -1,0 +1,45 @@
+name: WEVC CI/CD
+
+on:
+  push:
+    branches: [ master, ci-configuration ]
+
+jobs:
+
+  CI: 
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install frontend
+      run: cd frontend && yarn
+    - name: Test frontend
+      run: cd frontend && yarn test --watchAll=false --passWithNoTests 
+    - name: Cypress run
+      uses: cypress-io/github-action@v2
+      with:
+        working-directory: ./frontend
+        start: yarn start
+        wait-on: http://localhost:3000
+
+  CD:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Docker build
+        run: cd frontend && docker build -t front .
+      - name: Docker tag
+        run: docker tag front ${{ secrets.DOCKER_REPO }}:frontend-latest
+      - name: Docker push
+        run: docker push ${{ secrets.DOCKER_REPO }}:frontend-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,30 +1,47 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
+name: WEVC CI/CD
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, ci-configuration ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  build:
 
+  CI: 
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [14.x]
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: install and build frontend
-      run: cd frontend && yarn && yarn build
-    - name: test frontend
+    - name: Install frontend
+      run: cd frontend && yarn
+    - name: Test frontend
       run: cd frontend && yarn test --watchAll=false --passWithNoTests 
+    - name: Cypress run
+      uses: cypress-io/github-action@v2
+      with:
+        working-directory: ./frontend
+        start: yarn start
+        wait-on: http://localhost:3000
+
+  CD:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Docker build
+        run: cd frontend && docker build -t front .
+      - name: Docker tag
+        run: docker tag front ${{ secrets.DOCKER_REPO }}:frontend-latest
+      - name: Docker push
+        run: docker push ${{ secrets.DOCKER_REPO }}:frontend-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,6 @@
-name: WEVC CI/CD
+name: WEVC CI
 
 on:
-  push:
-    branches: [ master, ci-configuration ]
   pull_request:
     branches: [ master ]
 
@@ -29,19 +27,3 @@ jobs:
         working-directory: ./frontend
         start: yarn start
         wait-on: http://localhost:3000
-
-  CD:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker login
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Docker build
-        run: cd frontend && docker build -t front .
-      - name: Docker tag
-        run: docker tag front ${{ secrets.DOCKER_REPO }}:frontend-latest
-      - name: Docker push
-        run: docker push ${{ secrets.DOCKER_REPO }}:frontend-latest


### PR DESCRIPTION
closes #44 
closes #15 

* GitHub actions changes split into 2 parts
  * Master push - full CI/CD
    * CI = Install frontend, run normal frontend tests & run cypress tests
    * CD = Build and publish frontend image to dockerhub (https://hub.docker.com/repository/docker/ohtuprojekti/wevc) tagged with 
     `frontend-latest`. Requires CI to pass
  * Pull request - CI only
    * CI = Install frontend, run normal frontend tests & run cypress tests
* Actions tab should show ran action `WEVC CI/CD` for `ci-configuration` branch push and `WEVC CI` for pull request to verify operation
