### PR TITLE
Fix missing CI requirement for CD steps in workflow

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -29,6 +29,7 @@ jobs:
         wait-on: http://localhost:3000
 
   CD:
+    needs: CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#50 had a missing line of code and the master workflow didn't require CI (testing) for CD (docker deployment). This now fixes it.

Note: `ci-configuration` branch as a push target is to be fixed later so only master pushes trigger docker deployment.