### PR TITLE
Add backend docker hot-reload & docker-compose for server

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "ts-node-dev ./src/index.ts",
+    "dev": "ts-node-dev --respawn --transpile-only --exit-child src/",
     "start": "node ./build/src/index.js"
   },
   "devDependencies": {

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  
+  frontend:
+    command: yarn serve -s build -p 3000
+    image: ohtuprojekti/wevc:frontend-latest
+    stdin_open: true
+    ports:
+      - "3000:3000"
+
+  backend:
+    command: yarn start
+    image: ohtuprojekti/wevc:backend-latest
+    stdin_open: true
+    ports:
+      - "3001:3001"
+
+  watchtower:
+    image: v2tec/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,21 @@ version: "3"
 
 services:
   frontend:
+    command: yarn start
     build: ./frontend
     stdin_open: true
     volumes:
-      - ./frontend/:/usr/src/app
-      - ./frontend/node_modules:/usr/src/app/node_modules
+      - ./frontend/:/usr/src/frontend
+      - ./frontend/node_modules:/usr/src/frontend/node_modules
     ports:
       - "3000:3000"
 
   backend:
+    command: yarn dev
     build: ./backend
     stdin_open: true
+    volumes:
+      - ./backend/:/usr/src/app
+      - ./backend/node_modules:/usr/src/app/node_modules
     ports:
       - "3001:3001"
-

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:14-alpine
 
-RUN mkdir -p /usr/src/app/node_modules && \
-  chown -R node:node /usr/src/app
+RUN mkdir -p /usr/src/frontend/node_modules && \
+  chown -R node:node /usr/src/frontend
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/frontend
 
 USER node
 
 COPY --chown=node:node . .
-RUN yarn
+RUN yarn && yarn build && yarn add serve
 
 EXPOSE 3000
 


### PR DESCRIPTION
* Add hot-reload in backend functionality to development docker-compose
* Add production docker-compose to repo (this should be copied to server as soon as Github actions pushes backend)
* Add `serve` to frontend image, used to serve production version of frontend
  * Some other way of serving production frontend should be addressed later
    * Express + Apollo?