### PR TITLE
Add backend operations & documentation ignoring to github actions

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -2,31 +2,44 @@ name: WEVC CI/CD
 
 on:
   push:
-    branches: [ master, ci-configuration ]
+    branches: [master, ci-configuration]
+    paths-ignore:
+      - 'documentation/**'
+      - 'README.md'
+      - LICENSE
 
 jobs:
-
-  CI: 
+  CI:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install frontend
-      run: cd frontend && yarn
-    - name: Test frontend
-      run: cd frontend && yarn test --watchAll=false --passWithNoTests 
-    - name: Cypress run
-      uses: cypress-io/github-action@v2
-      with:
-        working-directory: ./frontend
-        start: yarn start
-        wait-on: http://localhost:3000
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install frontend
+        run: cd frontend && yarn
+      - name: Test frontend
+        run: cd frontend && yarn test --watchAll=false --passWithNoTests
+      - name: Build frontend
+        run: cd frontend && yarn build
+      - name: Install backend
+        run: cd backend && yarn
+      - name: Test backend
+        run: echo 'no tests yet'
+      - name: Build backend
+        run: cd backend && yarn build
+      - name: Start backend for Cypress tests
+        run: cd backend && nohup node build/src/index.js &
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ./frontend
+          start: yarn start
+          wait-on: http://localhost:3000
 
   CD:
     needs: CI
@@ -38,9 +51,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Docker build
+      - name: Docker build frontend
         run: cd frontend && docker build -t front .
-      - name: Docker tag
+      - name: Docker tag frontend
         run: docker tag front ${{ secrets.DOCKER_REPO }}:frontend-latest
-      - name: Docker push
+      - name: Docker push frontend
         run: docker push ${{ secrets.DOCKER_REPO }}:frontend-latest
+      - name: Docker build backend
+        run: cd backend && docker build -t back .
+      - name: Docker tag backend
+        run: docker tag back ${{ secrets.DOCKER_REPO }}:backend-latest
+      - name: Docker push backend
+        run: docker push ${{ secrets.DOCKER_REPO }}:backend-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,28 +2,40 @@ name: WEVC CI
 
 on:
   pull_request:
-    branches: [ master ]
-
+    branches: [master]
+    paths-ignore:
+      - 'documentation/**'
+      - 'README.md'
+      - LICENSE
 jobs:
-
-  CI: 
+  CI:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install frontend
-      run: cd frontend && yarn
-    - name: Test frontend
-      run: cd frontend && yarn test --watchAll=false --passWithNoTests 
-    - name: Cypress run
-      uses: cypress-io/github-action@v2
-      with:
-        working-directory: ./frontend
-        start: yarn start
-        wait-on: http://localhost:3000
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install frontend
+        run: cd frontend && yarn
+      - name: Test frontend
+        run: cd frontend && yarn test --watchAll=false --passWithNoTests
+      - name: Build frontend
+        run: cd frontend && yarn build
+      - name: Install backend
+        run: cd backend && yarn
+      - name: Test backend
+        run: echo 'no tests yet'
+      - name: Build backend
+        run: cd backend && yarn build
+      - name: Start backend for Cypress tests
+        run: cd backend && nohup node build/src/index.js &
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ./frontend
+          start: yarn start
+          wait-on: http://localhost:3000


### PR DESCRIPTION
closes #53 
closes #55 

* GitHub actions installs, builds, tests backend (no test script yet) and pushes image to our dockerhub
* Ignores runs when only README.md, LICENSE or documentation folder is modified (I think)