### PR TITLE
Express frontend serving & production mode fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+backend/node_modules
+frontend/node_modules
+frontend/build
+backend/build
+documentation
+userdata
+backend/repositories

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -62,20 +62,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Docker build frontend
-        run: cd frontend && docker build -t front .
+      - name: Docker build application
+        run: docker build -t application .
 
-      - name: Docker tag frontend
-        run: docker tag front ${{ secrets.DOCKER_REPO }}:frontend-latest
+      - name: Docker tag application
+        run: docker tag application ${{ secrets.DOCKER_REPO }}:application-latest
 
-      - name: Docker push frontend
-        run: docker push ${{ secrets.DOCKER_REPO }}:frontend-latest
-
-      - name: Docker build backend
-        run: cd backend && docker build -t back .
-
-      - name: Docker tag backend
-        run: docker tag back ${{ secrets.DOCKER_REPO }}:backend-latest
-
-      - name: Docker push backend
-        run: docker push ${{ secrets.DOCKER_REPO }}:backend-latest
+      - name: Docker push application
+        run: docker push ${{ secrets.DOCKER_REPO }}:application-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14-alpine AS front-build-stage
+
+COPY ./frontend ./frontend
+WORKDIR /frontend
+RUN yarn && yarn build
+
+FROM node:14-alpine
+
+RUN mkdir -p /usr/src/app/
+COPY ./backend /usr/src/app/backend
+WORKDIR /usr/src/app/backend
+RUN apk add git && yarn && yarn build 
+COPY --from=front-build-stage /frontend/build/ /usr/src/app/backend/build/
+
+EXPOSE 3001
+
+CMD ["yarn","start"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Web application to edit Robot Framework files remotely
 
 [General](documentation/general.md)
 
-[Application in production](http://135.181.89.96:3000/)
+[Application in production](http://135.181.89.96:3001/)
 
 [Frontend documentation](/documentation/frontend.md)
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "ts-node-dev --respawn --transpile-only --exit-child src/",
-    "start": "node ./build/src/index.js"
+    "start": "NODE_ENV=production node ./build/src/index.js"
   },
   "devDependencies": {
     "ts-node-dev": "^1.0.0-pre.63"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,12 +8,13 @@ import schema from './schema/schema'
 
 import { Req } from '../types/request'
 import User from './model/user'
+import path from 'path'
 
 const app = express()
 
 const corsOptions = {
   origin: true,
-  credentials: true
+  credentials: true,
 }
 
 interface TokenType {
@@ -24,21 +25,31 @@ const server = new ApolloServer({
   schema: schema,
   context: ({ req }: Req) => {
     const auth = req.headers.authorization
-    if ( auth && auth.toLowerCase().startsWith('bearer') ) {
+    if (auth && auth.toLowerCase().startsWith('bearer')) {
       const decodedToken = verify(auth.substring(7), config.JWT_SECRET)
-			const currentUser = User.getUserByGithubId((<TokenType>decodedToken).gitHubId)
-			return { currentUser }
+      const currentUser = User.getUserByGithubId(
+        (<TokenType>decodedToken).gitHubId
+      )
+      return { currentUser }
     }
     return null
-  }
+  },
 })
 
 server.applyMiddleware({ app, path: '/graphql' })
 server.applyMiddleware({ app, cors: corsOptions })
 
+if (process.env.NODE_ENV === 'production') {
+  app.use(express.static('build'))
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(__dirname, '../', 'index.html'))
+  })
+}
+
 const httpServer = createServer(app)
 
-httpServer.listen(
-  { port: config.PORT },
-  (): void => console.log(`GraphQL is now running on http://localhost:${config.PORT}/graphql`)
+httpServer.listen({ port: config.PORT }, (): void =>
+  console.log(
+    `GraphQL is now running on http://localhost:${config.PORT}/graphql`
+  )
 )

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,21 +1,18 @@
 version: '3'
 
 services:
-  frontend:
-    command: yarn serve -s build -p 3000
-    image: ohtuprojekti/wevc:frontend-latest
-    stdin_open: true
-    ports:
-      - '3000:3000'
-
-  backend:
-    command: yarn start
-    image: ohtuprojekti/wevc:backend-latest
+  application:
+    image: ohtuprojekti/wevc:application-latest
     stdin_open: true
     ports:
       - '3001:3001'
     depends_on:
       - userdata
+    environment:
+      - GH_CLIENT_ID=
+      - GH_CLIENT_SECRET=
+      - GH_CB_URL=
+      - JWT_SECRET=
 
   userdata:
     image: 'postgres'


### PR DESCRIPTION
closes #69 
* Backend hosts production frontend with express
  * Application uses only port 3001 
* Dockerfile added for production
* Github actions changed to push only this single docker image
* Production docker-compose changed to match changes
* Also fixes our server not fetching files in production mode
  * Side-effect: GraphQL playground not accessible in production environment (server) 