### PR TITLE
Staging at server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Web application to edit Robot Framework files remotely
 
 [General](documentation/general.md)
 
-[Application in production](http://135.181.89.96:3001/)
+[Application in production](http://135.181.89.96:4000/)
 
 [Frontend documentation](/documentation/frontend.md)
 
@@ -14,9 +14,8 @@ Web application to edit Robot Framework files remotely
 
 [Working hours](https://docs.google.com/spreadsheets/d/1YDC3QcxFgtNw_KvYTQlDE8rA0DA7rvMYv_ZlsHXdvww)
 
-
-
 ### Definition of done
-* Feature is implemented
-* Tests are passed
-* Code is reviewed: at least 2 persons have accepted changes in the pull request
+
+- Feature is implemented
+- Tests are passed
+- Code is reviewed: at least 2 persons have accepted changes in the pull request


### PR DESCRIPTION
closes #95 

Initial implementation of staging version started at our server. There was trouble running the production version in port `3001` after running a separate docker-compose for staging. 

So currently:

* Production version running at `http://135.181.89.96:4000/`
* Staging version running at `http://135.181.89.96:5000/`
  * New staging github app created
* All technical details documented in our google drive 
* Other deployment details addressed in #100 


If you feel that the port issue should be changed back to original, then let's try to fix that