### PR TITLE
Show current branch name in frontend save dialog

### DIFF
--- a/backend/src/schema/schema.ts
+++ b/backend/src/schema/schema.ts
@@ -7,6 +7,7 @@ const Query = `
         githubLoginUrl: String!
         me: User
         cloneRepository(url: String): [File]
+        getRepoState(url: String): RepoState!
     },
 `
 

--- a/backend/src/services/git.ts
+++ b/backend/src/services/git.ts
@@ -7,6 +7,14 @@ import { sanitizeCommitMessage, sanitizeBranchName } from '../utils/sanitize'
 import { validateBranchName } from '../utils/utils'
 import { SaveArgs } from '../types/params'
 
+export const getCurrentBranchName = async (
+  repoLocation: string
+): Promise<string> => {
+  const git = simpleGit(repoLocation)
+  const branches = await git.branchLocal()
+  return branches.current
+}
+
 export const pullMasterChanges = async (httpsURL: string): Promise<void> => {
   const url = new URL(httpsURL)
   const repositoryName = url.pathname

--- a/backend/src/types/repoState.ts
+++ b/backend/src/types/repoState.ts
@@ -1,0 +1,3 @@
+export interface RepoState {
+  branchName: string
+}

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -89,7 +89,8 @@ const MonacoEditor = ({ content, filename }: Props) => {
             userQueryLoading ||
             !!userQueryError ||
             mutationSaveLoading ||
-            !user.me
+            !user.me ||
+            branchState.loading
           }
           onClick={handleSaveButton}
         >

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -1,10 +1,11 @@
 import React, { useRef, useState } from 'react'
 import Editor from '@monaco-editor/react'
 import { useMutation, useQuery } from '@apollo/client'
-import { ME } from '../graphql/queries'
+import { BRANCH_STATE, ME } from '../graphql/queries'
 import { SAVE_CHANGES } from '../graphql/mutations'
 import { Button } from '@material-ui/core'
 import SaveDialog from './SaveDialog'
+import { RepoStateQueryResult } from '../types'
 
 interface Props {
   content: string | undefined
@@ -17,7 +18,9 @@ interface Getter {
 
 const MonacoEditor = ({ content, filename }: Props) => {
   const [dialogOpen, setDialogOpen] = useState(false)
-  const currentBranch = 'master' // get this from somewhere
+
+  const branchState = useQuery<RepoStateQueryResult>(BRANCH_STATE)
+  const currentBranch = branchState.data?.repoState.branchName || ''
 
   const {
     loading: userQueryLoading,

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -11,6 +11,16 @@ export const ALL_FILES = gql`
   }
 `
 
+export const BRANCH_STATE = gql`
+  query {
+    repoState: getRepoState(
+      url: "https://github.com/ohtuprojekti-eficode/robot-test-files"
+    ) {
+      branchName
+    }
+  }
+`
+
 export const GITHUB_LOGIN_URL = gql`
   query {
     githubLoginUrl

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,12 @@ export interface FileListQueryResult {
   files: File[]
 }
 
+export interface RepoStateQueryResult {
+  repoState: {
+    branchName: string
+  }
+}
+
 export interface Error {
   message: string
 }


### PR DESCRIPTION
closes #133 

* Started GraphQL query for getting the current state of repository
  * Currently only returns active branch name
  * Current files could be added to the query later
* Fetch currently active branch name to frontend save modal
  * Couldn't make this automatically update with the click of a save. User has to refresh the page after a save if the save is made to new branch (to see the updated branch name in the second save)
  * Tried GraphQL `useLazyQuery` but maybe someone could help me with improving this later