### PR TITLE
Remove useless build from dev dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,10 +8,9 @@ RUN apk add git
 
 USER node
 
-
 COPY --chown=node:node . .
-RUN yarn && yarn build
+RUN yarn
 
 EXPOSE 3001
 
-CMD ["yarn","start"]
+CMD ["yarn","dev"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/frontend
 USER node
 
 COPY --chown=node:node . .
-RUN yarn && yarn build && yarn add serve
+RUN yarn
 
 EXPOSE 3000
 


### PR DESCRIPTION
`frontend/Dockerfile` & `backend/Dockerfile` had useless `yarn build` because they're only used for development. This was just taking useless time when doing `docker-compose build` and decided to do a very quick fix for this.