### PR TITLE
Issue156: Improve query for repository state

### DIFF
--- a/backend/src/schema/repository.ts
+++ b/backend/src/schema/repository.ts
@@ -31,6 +31,22 @@ const typeDef = `
 
 const resolvers = {
   Query: {
+    cloneRepository: async (
+      _root: unknown,
+      args: { url: string },
+      _context: unknown
+    ): Promise<string> => {
+      const url = new URL(args.url)
+      const repositoryName = url.pathname
+      const fileLocation = `./repositories/${repositoryName}`
+
+      if (!existsSync(fileLocation)) {
+        await cloneRepository(url.href)
+      } else {
+        await pullMasterChanges(url.href)
+      }
+      return 'Cloned'
+    },
     getRepoState: async (
       _root: unknown,
       args: { url: string },
@@ -39,12 +55,6 @@ const resolvers = {
       const url = new URL(args.url)
       const repositoryName = url.pathname
       const repoLocation = `./repositories/${repositoryName}`
-
-      if (!existsSync(repoLocation)) {
-        await cloneRepository(url.href)
-      } else {
-        await pullMasterChanges(url.href)
-      }
 
       const currentBranch = await getCurrentBranchName(repoLocation)
 

--- a/backend/src/schema/schema.ts
+++ b/backend/src/schema/schema.ts
@@ -7,6 +7,7 @@ const Query = `
         githubLoginUrl: String!
         me: User
         getRepoState(url: String): RepoState!
+        cloneRepository(url: String!): String
     },
 `
 

--- a/backend/src/schema/schema.ts
+++ b/backend/src/schema/schema.ts
@@ -6,9 +6,7 @@ const Query = `
     type Query {
         githubLoginUrl: String!
         me: User
-        cloneRepository(url: String): [File]
         getRepoState(url: String): RepoState!
-        getRepoBranches(url: String!): [String]!
     },
 `
 

--- a/backend/src/services/git.ts
+++ b/backend/src/services/git.ts
@@ -148,7 +148,8 @@ const gitRemoveRemote = async (git: SimpleGit, remoteId: string) => {
   await git.removeRemote(remoteId)
 }
 
-export const getBranches = async (git: SimpleGit): Promise<string[]> => {
+export const getBranches = async (repoLocation: string): Promise<string[]> => {
+  const git = simpleGit(repoLocation)
   const branches = await git.branch()
   return branches.all
 }

--- a/backend/src/tests/git.test.ts
+++ b/backend/src/tests/git.test.ts
@@ -18,7 +18,7 @@ describe('Get branches', () => {
     const testRepo = simpleGit(repoPath)
     await testRepo.init()
 
-    const branches = await getBranches(testRepo)
+    const branches = await getBranches(repoPath)
     expect(branches).toEqual([])
   })
 
@@ -37,7 +37,7 @@ describe('Get branches', () => {
       .commit('init commit')
       .branch(['secondBranch'])
 
-    const branches = await getBranches(testRepo)
+    const branches = await getBranches(repoPath)
     expect(branches).toEqual(['master', 'secondBranch'])
   })
 })

--- a/backend/src/tests/repository.test.ts
+++ b/backend/src/tests/repository.test.ts
@@ -1,20 +1,26 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import { gql } from 'apollo-server'
-import { ApolloServer } from 'apollo-server-express'
 import { createTestClient } from 'apollo-server-testing'
 import { appendFileSync, mkdirSync, rmdirSync } from 'fs'
 import { join } from 'path'
 import simpleGit from 'simple-git'
-import schema from '../schema/schema'
+import { server } from '../index'
 
-const GET_BRANCHES = gql`
-  query branches($url: String!) {
-    getRepoBranches(url: $url)
+const GET_REPO_STATE = gql`
+  query repoState($url: String!) {
+    getRepoState(url: $url) {
+      currentBranch
+      files {
+        name
+        content
+      }
+      branches
+    }
   }
 `
 
-describe('Getbranches query', () => {
+describe('getRepoState query', () => {
   const repoPath = join('.', 'repositories', 'testRepo')
 
   beforeEach(async () => {
@@ -26,28 +32,21 @@ describe('Getbranches query', () => {
     rmdirSync(repoPath, { recursive: true })
   })
 
-  it('return empty list if no branches', async () => {
-    const server = new ApolloServer({
-      schema,
-    })
-
+  it('list of all branches is empty when no branches exist', async () => {
     const { query } = createTestClient(server)
 
     const res = await query({
-      query: GET_BRANCHES,
+      query: GET_REPO_STATE,
       variables: {
         url: 'http://www.remote.org/testRepo',
       },
     })
 
-    expect(res.data?.getRepoBranches).toEqual([])
+    const branches = res.data?.getRepoState.branches
+    expect(branches).toEqual([])
   })
 
-  it('returns [master, secondbranch]', async () => {
-    const server = new ApolloServer({
-      schema,
-    })
-
+  it('list of all branches contains correct branches', async () => {
     appendFileSync(
       `${repoPath}/file.txt`,
       'Commit and add file to create master branch'
@@ -64,12 +63,100 @@ describe('Getbranches query', () => {
     const { query } = createTestClient(server)
 
     const res = await query({
-      query: GET_BRANCHES,
+      query: GET_REPO_STATE,
       variables: {
         url: 'http://www.remote.org/testRepo',
       },
     })
 
-    expect(res.data?.getRepoBranches).toEqual(['master', 'secondBranch'])
+    const branches = res.data?.getRepoState.branches
+    expect(branches).toEqual(['master', 'secondBranch'])
+  })
+
+  it('list of current files is empty when no files exist', async () => {
+    const { query } = createTestClient(server)
+
+    const res = await query({
+      query: GET_REPO_STATE,
+      variables: {
+        url: 'http://www.remote.org/testRepo',
+      },
+    })
+
+    const files = res.data?.getRepoState.files
+    expect(files).toEqual([])
+  })
+
+  it('list of all files contains correct files', async () => {
+    appendFileSync(
+      `${repoPath}/file.txt`,
+      'Commit and add file to create master branch'
+    )
+
+    const testRepo = simpleGit(repoPath)
+    await testRepo
+      .addConfig('user.name', 'Some One')
+      .addConfig('user.email', 'some@one.com')
+      .add('.')
+      .commit('init commit')
+      .branch(['secondBranch'])
+
+    const { query } = createTestClient(server)
+
+    const res = await query({
+      query: GET_REPO_STATE,
+      variables: {
+        url: 'http://www.remote.org/testRepo',
+      },
+    })
+
+    const files = res.data?.getRepoState.files
+    const fakeFile = {
+      name: `testRepo/file.txt`,
+      content: 'Commit and add file to create master branch',
+    }
+    const expectedFiles = [fakeFile]
+    expect(files).toEqual(expectedFiles)
+  })
+
+  it('current branch name is empty when branch status is unknown', async () => {
+    const { query } = createTestClient(server)
+
+    const res = await query({
+      query: GET_REPO_STATE,
+      variables: {
+        url: 'http://www.remote.org/testRepo',
+      },
+    })
+
+    const currentBranch = res.data?.getRepoState.currentBranch
+    expect(currentBranch).toEqual('')
+  })
+
+  it('current branch name is correct', async () => {
+    appendFileSync(
+      `${repoPath}/file.txt`,
+      'Commit and add file to create master branch'
+    )
+
+    const testRepo = simpleGit(repoPath)
+    await testRepo
+      .addConfig('user.name', 'Some One')
+      .addConfig('user.email', 'some@one.com')
+      .add('.')
+      .commit('init commit')
+      .branch(['secondBranch'])
+
+    const { query } = createTestClient(server)
+
+    const res = await query({
+      query: GET_REPO_STATE,
+      variables: {
+        url: 'http://www.remote.org/testRepo',
+      },
+    })
+
+    const currentBranch = res.data?.getRepoState.currentBranch
+    expect(currentBranch).toEqual('master')
   })
 })

--- a/backend/src/types/repoState.ts
+++ b/backend/src/types/repoState.ts
@@ -1,3 +1,7 @@
+import { File } from './file'
+
 export interface RepoState {
-  branchName: string
+  currentBranch: string
+  files: File[]
+  branches: string[]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import { Route, Link } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
-import { ALL_FILES } from './graphql/queries'
 import { ME } from './graphql/queries'
 import EditView from './components/EditView'
 import LoginForm from './components/LoginForm'
 import CallBack from './components/auth/CallBack'
-import { FileListQueryResult } from './types'
 
 const App = () => {
-  const { loading, data, error } = useQuery<FileListQueryResult>(ALL_FILES)
   const { data: user } = useQuery(ME)
 
   const padding = {
@@ -46,7 +43,7 @@ const App = () => {
           <CallBack />
         </Route>
         <Route path="/edit">
-          <EditView loading={loading} data={data} error={error} />
+          <EditView />
         </Route>
         <Route exact path="/login" component={LoginForm} />
       </div>

--- a/frontend/src/components/EditView.tsx
+++ b/frontend/src/components/EditView.tsx
@@ -2,22 +2,18 @@ import React from 'react'
 import MonacoEditor from './MonacoEditor'
 import ListView from './ListView'
 import { useLocation } from 'react-router-dom'
-import { FileListQueryResult } from '../types'
-import { ApolloError } from '@apollo/client'
+import { useQuery } from '@apollo/client'
+import { RepoStateQueryResult } from '../types'
+import { REPO_STATE } from '../graphql/queries'
 
-interface PropsType {
-  loading: boolean
-  data: FileListQueryResult | undefined
-  error: ApolloError | undefined
-}
-
-const EditView = ({ loading, data, error }: PropsType) => {
+const EditView = () => {
+  const repoStateQuery = useQuery<RepoStateQueryResult>(REPO_STATE)
   const location = useLocation()
 
-  if (loading) return <div>Loading files...</div>
-  if (error) return <div>Error fetching files...</div>
+  if (repoStateQuery.loading) return <div>Loading repo files...</div>
+  if (repoStateQuery.error) return <div>Error loading repo files...</div>
 
-  const files = data ? data.files : []
+  const files = repoStateQuery.data ? repoStateQuery.data.repoState.files : []
   const filename = location.search.slice(3)
   const content = files.find((e) => e.name === filename)?.content
 

--- a/frontend/src/components/EditView.tsx
+++ b/frontend/src/components/EditView.tsx
@@ -8,10 +8,9 @@ import { REPO_STATE, CLONE_REPO } from '../graphql/queries'
 
 const EditView = () => {
   const location = useLocation()
-  const [
-    repoStateQuery,
-    { loading: repoStateLoading, error: repoStateError, data: repoStateData },
-  ] = useLazyQuery<RepoStateQueryResult>(REPO_STATE)
+  const [repoStateQuery, { data: repoStateData }] = useLazyQuery<
+    RepoStateQueryResult
+  >(REPO_STATE)
   const cloneRepoQuery = useQuery(CLONE_REPO, {
     onCompleted: () => repoStateQuery(),
   })

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react'
 import Editor from '@monaco-editor/react'
 import { useMutation, useQuery } from '@apollo/client'
-import { BRANCH_STATE, ME } from '../graphql/queries'
+import { ME, REPO_STATE } from '../graphql/queries'
 import { SAVE_CHANGES } from '../graphql/mutations'
 import { Button } from '@material-ui/core'
 import SaveDialog from './SaveDialog'
@@ -18,8 +18,8 @@ interface Getter {
 
 const MonacoEditor = ({ content, filename }: Props) => {
   const [dialogOpen, setDialogOpen] = useState(false)
-  const branchState = useQuery<RepoStateQueryResult>(BRANCH_STATE)
-  const currentBranch = branchState.data?.repoState.branchName || ''
+  const branchState = useQuery<RepoStateQueryResult>(REPO_STATE)
+  const currentBranch = branchState.data?.repoState.currentBranch || ''
 
   const {
     loading: userQueryLoading,
@@ -28,8 +28,9 @@ const MonacoEditor = ({ content, filename }: Props) => {
   } = useQuery(ME)
 
   const [saveChanges, { loading: mutationSaveLoading }] = useMutation(
-    SAVE_CHANGES, {
-      refetchQueries: [ { query: BRANCH_STATE } ]
+    SAVE_CHANGES,
+    {
+      refetchQueries: [{ query: REPO_STATE }],
     }
   )
 
@@ -58,7 +59,7 @@ const MonacoEditor = ({ content, filename }: Props) => {
           },
           branch: branchName,
           commitMessage: commitMessage,
-        }
+        },
       })
     }
     setDialogOpen(false)

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -1,22 +1,16 @@
 import { gql } from '@apollo/client'
 
-export const ALL_FILES = gql`
-  query {
-    files: cloneRepository(
-      url: "https://github.com/ohtuprojekti-eficode/robot-test-files"
-    ) {
-      name
-      content
-    }
-  }
-`
-
-export const BRANCH_STATE = gql`
+export const REPO_STATE = gql`
   query {
     repoState: getRepoState(
       url: "https://github.com/ohtuprojekti-eficode/robot-test-files"
     ) {
-      branchName
+      currentBranch
+      files {
+        name
+        content
+      }
+      branches
     }
   }
 `

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -15,6 +15,14 @@ export const REPO_STATE = gql`
   }
 `
 
+export const CLONE_REPO = gql`
+  query {
+    cloneRepo: cloneRepository(
+      url: "https://github.com/ohtuprojekti-eficode/robot-test-files"
+    )
+  }
+`
+
 export const GITHUB_LOGIN_URL = gql`
   query {
     githubLoginUrl

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -9,7 +9,9 @@ export interface FileListQueryResult {
 
 export interface RepoStateQueryResult {
   repoState: {
-    branchName: string
+    currentBranch: string
+    files: File[]
+    branches: string[]
   }
 }
 


### PR DESCRIPTION
closes #156 

* `getRepoState` query now returns: current branch name, files in the repo (in current branch) and list of all branch names
  * Removed `getRepoBranches` query as a duplicate
  * Changed `cloneRepository` query to not return current files anymore
* Changes to frontend to fix current functionality with new queries
  * `EditView` component queries repo cloning and repo state
  * Frontend is a big mess at the moment, I think `MonacoEditor` component shouldn't do any queries anymore but I left this untouched to address this issue in a different PR
* Added tests for this query
  * Some duplicate code and typescript ESLint errors, is this an issue?