### PR TITLE
Make docker-compose build faster

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,6 @@ RUN apk add git
 USER node
 
 COPY --chown=node:node . .
-RUN yarn
 
 EXPOSE 3001
 

--- a/documentation/backend.md
+++ b/documentation/backend.md
@@ -21,18 +21,10 @@
 
 ### Starting backend without frontend
 
-##### Without docker
-
 1. Go to `backend` folder
 2. Run `yarn` to install depencies
 3. Run `yarn tsc` to compile
 4. Run `yarn start` and the server should launch to `localhost:3001`
-
-##### With docker
-
-1. Go to `backend` folder
-2. Run `docker build --tag backend .` to build the backend image
-3. Start the image with `docker run -p 3001:3001 backend` and the server should launch to `localhost:3001`
 
 ### GraphQL queries and mutations
 

--- a/documentation/frontend.md
+++ b/documentation/frontend.md
@@ -18,12 +18,6 @@
 
 ### Starting frontend without backend
 
-##### Without docker
 1. Go to `frontend` folder
 2. Run `yarn` to install depencies
 3. Run `yarn start` and the application should launch to `localhost:3000`
-
-##### With docker
-1. Go to `frontend` folder
-2. Run `docker build --tag frontend .` to build the frontend image
-3. Start the image with `docker run -p 3000:3000 frontend` and the application should launch to `localhost:3000`

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /usr/src/frontend
 USER node
 
 COPY --chown=node:node . .
-RUN yarn
 
 EXPOSE 3000
 


### PR DESCRIPTION
Realized that development `Dockerfile`'s don't need to install everything with `yarn` because they're meant to be run with our `docker-compose` and the `node_modules` are cloned from developer computer. This will break the dockerfiles so that they can't be run without our `docker-compose` but makes `docker-compose build` a lot faster.

Just remember to run `yarn` in `/backend` and `/frontend` folders before `docker-compose up` (as before)