### PR TITLE
Issue163 update file listing

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -41,7 +41,7 @@ jobs:
           cd frontend
           yarn
           yarn build
-          yarn test --watchAll=false --passWithNoTests
+          yarn test --watchAll=false
 
       - name: Install, build and test backend
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
           cd frontend
           yarn
           yarn build
-          yarn test --watchAll=false --passWithNoTests
+          yarn test --watchAll=false
 
       - name: Install, build and test backend
         run: |

--- a/.github/workflows/staging_push.yml
+++ b/.github/workflows/staging_push.yml
@@ -41,7 +41,7 @@ jobs:
           cd frontend
           yarn
           yarn build
-          yarn test --watchAll=false --passWithNoTests
+          yarn test --watchAll=false
 
       - name: Install, build and test backend
         run: |

--- a/frontend/cypress/integration/editor/editor.spec.js
+++ b/frontend/cypress/integration/editor/editor.spec.js
@@ -15,12 +15,12 @@ describe('When visiting the edit view page, as a user', () => {
   })
 
   it('I can view the file listing', () => {
-    cy.contains('Files in the repository')
+    cy.contains('new_folder')
   })
 
   it('I can open a file in editor', () => {
     cy.contains('example.txt').click()
-    cy.contains('ohtuprojekti-eficode/robot-test-files/example.txt')
+    cy.get('h2').contains('example.txt')
   })
 
   it('I can edit a file in editor and see a save button', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { ME } from './graphql/queries'
 import EditView from './components/EditView'
 import LoginForm from './components/LoginForm'
 import CallBack from './components/auth/CallBack'
+import { AppBar, Toolbar } from '@material-ui/core'
 
 const App = () => {
   const { data: user } = useQuery(ME)
@@ -20,24 +21,26 @@ const App = () => {
 
   return (
     <div>
-      <div>
-        <Link style={padding} to="/">
-          Main menu
-        </Link>
-        <Link style={padding} to="/edit">
-          Edit view
-        </Link>
-        {(!user || !user.me) && (
-          <Link style={padding} to="/login">
-            Login
+      <AppBar position="fixed" color="default" style={{ zIndex: 1250 }}>
+        <Toolbar>
+          <Link style={padding} to="/">
+            Main menu
           </Link>
-        )}
-        {user && user.me && (
-          <Link style={padding} to="/" onClick={logout}>
-            {user.me.username} - logout
+          <Link style={padding} to="/edit">
+            Edit view
           </Link>
-        )}
-      </div>
+          {(!user || !user.me) && (
+            <Link style={padding} to="/login">
+              Login
+            </Link>
+          )}
+          {user && user.me && (
+            <Link style={padding} to="/" onClick={logout}>
+              {user.me.username} - logout
+            </Link>
+          )}
+        </Toolbar>
+      </AppBar>
       <div>
         <Route path="/auth/github/callback">
           <CallBack />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const App = () => {
         </Toolbar>
       </AppBar>
       <div>
+        <Toolbar />
         <Route path="/auth/github/callback">
           <CallBack />
         </Route>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,15 @@
 import React from 'react'
-import { Route, Link } from 'react-router-dom'
+import { Route } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { ME } from './graphql/queries'
 import EditView from './components/EditView'
+import Header from './components/Header'
 import LoginForm from './components/LoginForm'
 import CallBack from './components/auth/CallBack'
-import { AppBar, Toolbar } from '@material-ui/core'
+import { Toolbar } from '@material-ui/core'
 
 const App = () => {
   const { data: user } = useQuery(ME)
-
-  const padding = {
-    paddingRight: 5,
-  }
 
   const logout = () => {
     localStorage.clear()
@@ -21,26 +18,7 @@ const App = () => {
 
   return (
     <div>
-      <AppBar position="fixed" color="default" style={{ zIndex: 1250 }}>
-        <Toolbar>
-          <Link style={padding} to="/">
-            Main menu
-          </Link>
-          <Link style={padding} to="/edit">
-            Edit view
-          </Link>
-          {(!user || !user.me) && (
-            <Link style={padding} to="/login">
-              Login
-            </Link>
-          )}
-          {user && user.me && (
-            <Link style={padding} to="/" onClick={logout}>
-              {user.me.username} - logout
-            </Link>
-          )}
-        </Toolbar>
-      </AppBar>
+      <Header user={user?.me} logout={logout} />
       <div>
         <Toolbar />
         <Route path="/auth/github/callback">

--- a/frontend/src/components/EditView.tsx
+++ b/frontend/src/components/EditView.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import MonacoEditor from './MonacoEditor'
-import ListView from './ListView'
+import Sidebar from './Sidebar'
 import { useLocation } from 'react-router-dom'
 import { useLazyQuery, useQuery } from '@apollo/client'
 import { RepoStateQueryResult } from '../types'
 import { REPO_STATE, CLONE_REPO } from '../graphql/queries'
+import { createStyles, makeStyles } from '@material-ui/core/styles'
 
 const EditView = () => {
   const location = useLocation()
+  const classes = useStyles()
+
   const [repoStateQuery, { data: repoStateData }] = useLazyQuery<
     RepoStateQueryResult
   >(REPO_STATE)
@@ -27,29 +30,30 @@ const EditView = () => {
   const content = files.find((e) => e.name === filename)?.content
 
   return (
-    <div style={gridContainerStyle}>
-      <div style={asideContainerStyle}>
-        <ListView files={files} />
+    <div className={classes.root}>
+      <div className={classes.sidebar}>
+        <Sidebar files={files} />
       </div>
-      <div style={mainContainerStyle}>
-        <h2>{filename}</h2>
+      <div className={classes.editor}>
         <MonacoEditor content={content} filename={filename} />
       </div>
     </div>
   )
 }
 
-const gridContainerStyle = {
-  display: 'flex',
-  justifyContent: 'space-between',
-}
-
-const asideContainerStyle = {
-  width: '20%',
-}
-
-const mainContainerStyle = {
-  width: '80%',
-}
+const useStyles = makeStyles(() =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    sidebar: {
+      flexShrink: 0,
+      width: 400,
+    },
+    editor: {
+      flexGrow: 1,
+    },
+  })
+)
 
 export default EditView

--- a/frontend/src/components/EditView.tsx
+++ b/frontend/src/components/EditView.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles(() =>
     },
     sidebar: {
       flexShrink: 0,
-      width: 400,
+      width: '20%',
     },
     editor: {
       flexGrow: 1,

--- a/frontend/src/components/FileTreeView.tsx
+++ b/frontend/src/components/FileTreeView.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles({
   },
 })
 
-const ListView = ({ files }: PropsType) => {
+const FileTreeView = ({ files }: PropsType) => {
   const [fileTree, setFileTree] = useState<FileTree>()
 
   const classes = useStyles()
@@ -71,4 +71,4 @@ const ListView = ({ files }: PropsType) => {
   )
 }
 
-export default ListView
+export default FileTreeView

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { AppBar, Toolbar } from '@material-ui/core'
+import { Link } from 'react-router-dom'
+import { UserType } from '../types'
+
+interface Props {
+  user: UserType
+  logout: () => void
+}
+
+const padding = {
+  paddingRight: 5,
+}
+
+const Header = ({ user, logout }: Props) => {
+  return (
+    <AppBar position="fixed" color="default" style={{ zIndex: 1250 }}>
+      <Toolbar>
+        <Link style={padding} to="/">
+          Main menu
+        </Link>
+        <Link style={padding} to="/edit">
+          Edit view
+        </Link>
+        {!user && (
+          <Link style={padding} to="/login">
+            Login
+          </Link>
+        )}
+        {user && (
+          <Link style={padding} to="/" onClick={logout}>
+            {user.username} - logout
+          </Link>
+        )}
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default Header

--- a/frontend/src/components/ListView.tsx
+++ b/frontend/src/components/ListView.tsx
@@ -1,23 +1,73 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import { File } from '../types'
+import React, { useEffect, useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import { ChevronRight, ExpandMore } from '@material-ui/icons'
+import { TreeItem, TreeView } from '@material-ui/lab'
+import { File, FileTree } from '../types'
+import { makeStyles } from '@material-ui/core/styles'
+import { parseToFileTree } from '../utils/files'
 
 interface PropsType {
   files: File[]
 }
 
+const useStyles = makeStyles({
+  root: {
+    height: 110,
+    flexGrow: 1,
+    maxWidth: 400,
+  },
+})
+
 const ListView = ({ files }: PropsType) => {
+  const [fileTree, setFileTree] = useState<FileTree>()
+
+  const classes = useStyles()
+  const history = useHistory()
+
+  useEffect(() => {
+    setFileTree(parseToFileTree(files))
+  }, [files])
+
+  const handleClick = (path: string, type: string) => {
+    if (type === 'folder') {
+      return () => {}
+    }
+    return () => {
+      history.push(`edit?q=${path}`)
+    }
+  }
+
+  const renderTree = (fileTree: FileTree) => {
+    return fileTree.children.map((node) => buildTree(node))
+  }
+
+  const buildTree = (fileTree: FileTree) => {
+    return (
+      <TreeItem
+        key={fileTree.path}
+        nodeId={fileTree.path}
+        onClick={handleClick(fileTree.path, fileTree.type)}
+        label={fileTree.name}
+      >
+        {fileTree.children.length !== 0
+          ? fileTree.children.map((node) => buildTree(node))
+          : null}
+      </TreeItem>
+    )
+  }
+
+  if (!fileTree) {
+    return <div>No files...</div>
+  }
+
   return (
-    <div>
-      <h2>Files in the repository</h2>
-      <ul>
-        {files.map((e) => (
-          <li key={e.name}>
-            <Link to={`edit?q=${e.name}`}>{e.name}</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <TreeView
+      className={classes.root}
+      defaultCollapseIcon={<ExpandMore />}
+      defaultExpandIcon={<ChevronRight />}
+    >
+      {renderTree(fileTree)}
+    </TreeView>
   )
 }
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
+import { Toolbar } from '@material-ui/core'
 import GitHubAuthBtn from './auth/GitHubAuthBtn'
 
 const LoginForm = () => {
-
   return (
     <div style={{ marginTop: 15, marginLeft: 5 }}>
-        <GitHubAuthBtn />
+      <Toolbar />
+      <GitHubAuthBtn />
     </div>
   )
 }

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import { Toolbar } from '@material-ui/core'
 import GitHubAuthBtn from './auth/GitHubAuthBtn'
 
 const LoginForm = () => {
   return (
     <div style={{ marginTop: 15, marginLeft: 5 }}>
-      <Toolbar />
       <GitHubAuthBtn />
     </div>
   )

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -3,7 +3,7 @@ import Editor from '@monaco-editor/react'
 import { useMutation, useQuery } from '@apollo/client'
 import { ME, REPO_STATE } from '../graphql/queries'
 import { SAVE_CHANGES } from '../graphql/mutations'
-import { Button } from '@material-ui/core'
+import { Button, Toolbar } from '@material-ui/core'
 import SaveDialog from './SaveDialog'
 import { RepoStateQueryResult } from '../types'
 
@@ -70,9 +70,11 @@ const MonacoEditor = ({ content, filename }: Props) => {
   }
 
   return (
-    <div style={{ border: '2px solid black', padding: '5px' }}>
+    <div>
+      <Toolbar />
+      <h2>{filename}</h2>
       <Editor
-        height="50vh"
+        height="75vh"
         language="javascript"
         value={content}
         editorDidMount={handleEditorDidMount}

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -3,7 +3,7 @@ import Editor from '@monaco-editor/react'
 import { useMutation, useQuery } from '@apollo/client'
 import { ME, REPO_STATE } from '../graphql/queries'
 import { SAVE_CHANGES } from '../graphql/mutations'
-import { Button, Toolbar } from '@material-ui/core'
+import { Button } from '@material-ui/core'
 import SaveDialog from './SaveDialog'
 import { RepoStateQueryResult } from '../types'
 
@@ -71,7 +71,6 @@ const MonacoEditor = ({ content, filename }: Props) => {
 
   return (
     <div>
-      <Toolbar />
       <h2>{filename}</h2>
       <Editor
         height="75vh"

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -71,7 +71,7 @@ const MonacoEditor = ({ content, filename }: Props) => {
 
   return (
     <div>
-      <h2>{filename}</h2>
+      <h2>{filename?.substring(filename.lastIndexOf('/') + 1)}</h2>
       <Editor
         height="75vh"
         language="javascript"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Drawer, Toolbar } from '@material-ui/core'
-import ListView from './ListView'
+import FileTreeView from './FileTreeView'
 import { File } from '../types'
 
 interface Props {
@@ -11,7 +11,7 @@ const Sidebar = ({ files }: Props) => {
   return (
     <Drawer variant="permanent" PaperProps={{ style: { width: '20%' } }}>
       <Toolbar />
-      <ListView files={files} />
+      <FileTreeView files={files} />
     </Drawer>
   )
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const Sidebar = ({ files }: Props) => {
   return (
-    <Drawer variant="permanent" PaperProps={{ style: { width: 400 } }}>
+    <Drawer variant="permanent" PaperProps={{ style: { width: '20%' } }}>
       <Toolbar />
       <ListView files={files} />
     </Drawer>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Drawer, Toolbar } from '@material-ui/core'
+import ListView from './ListView'
+import { File } from '../types'
+
+interface Props {
+  files: File[]
+}
+
+const Sidebar = ({ files }: Props) => {
+  return (
+    <Drawer variant="permanent" PaperProps={{ style: { width: 400 } }}>
+      <Toolbar />
+      <ListView files={files} />
+    </Drawer>
+  )
+}
+
+export default Sidebar

--- a/frontend/src/tests/files.test.ts
+++ b/frontend/src/tests/files.test.ts
@@ -1,0 +1,167 @@
+import { parseToFileTree, addToFileTree } from '../utils/files'
+import { File, FileTree } from '../types'
+
+describe('Add to file tree', () => {
+  const expectedTree: FileTree = {
+    name: 'src',
+    path: 'src',
+    type: 'root',
+    children: [
+      {
+        name: 'folder1',
+        path: 'src/folder1',
+        type: 'folder',
+        children: [
+          {
+            name: 'new_file.txt',
+            path: 'src/folder1/new_file.txt',
+            type: 'file',
+            children: [],
+          },
+        ],
+      },
+      { name: 'folder2', path: 'src/folder2', type: 'folder', children: [] },
+      { name: 'index.ts', path: 'src/index.ts', type: 'file', children: [] },
+    ],
+  }
+  it('adds a file to the tree', () => {
+    const tree: FileTree = {
+      name: 'src',
+      path: 'src',
+      type: 'root',
+      children: [
+        { name: 'folder1', path: 'src/folder1', type: 'folder', children: [] },
+        { name: 'folder2', path: 'src/folder2', type: 'folder', children: [] },
+        { name: 'index.ts', path: 'src/index.ts', type: 'file', children: [] },
+      ],
+    }
+    addToFileTree(tree, 'src/folder1/new_file.txt', 1)
+    expect(tree).toEqual(expectedTree)
+  })
+  it('adds file and required folders to tree', () => {
+    const tree: FileTree = {
+      name: 'src',
+      path: 'src',
+      type: 'root',
+      children: [
+        { name: 'index.ts', path: 'src/index.ts', type: 'file', children: [] },
+        { name: 'folder2', path: 'src/folder2', type: 'folder', children: [] },
+      ],
+    }
+    addToFileTree(tree, 'src/folder1/new_file.txt', 1)
+    expect(tree).toEqual(expectedTree)
+  })
+})
+
+describe('Parse to file tree', () => {
+  const files: File[] = [
+    { name: 'project/src/index.js', content: 'a' },
+    { name: 'project/src/index/test.txt', content: 'b' },
+    { name: 'project/src/tests/test2.ts', content: 'c' },
+    { name: 'project/src/tests/test.js', content: 'd' },
+  ]
+
+  it('returns a tree describing the directory structure', () => {
+    const tree: FileTree = {
+      name: 'project/src',
+      path: 'project/src',
+      type: 'root',
+      children: [
+        {
+          name: 'index',
+          path: 'project/src/index',
+          type: 'folder',
+          children: [
+            {
+              name: 'test.txt',
+              path: 'project/src/index/test.txt',
+              type: 'file',
+              children: [],
+            },
+          ],
+        },
+        {
+          name: 'tests',
+          path: 'project/src/tests',
+          type: 'folder',
+          children: [
+            {
+              name: 'test.js',
+              path: 'project/src/tests/test.js',
+              type: 'file',
+              children: [],
+            },
+            {
+              name: 'test2.ts',
+              path: 'project/src/tests/test2.ts',
+              type: 'file',
+              children: [],
+            },
+          ],
+        },
+        {
+          name: 'index.js',
+          path: 'project/src/index.js',
+          type: 'file',
+          children: [],
+        },
+      ],
+    }
+    expect(parseToFileTree(files)).toEqual(tree)
+  })
+  it('returns a different tree when root offset is changed', () => {
+    const tree: FileTree = {
+      name: 'project',
+      path: 'project',
+      type: 'root',
+      children: [
+        {
+          name: 'src',
+          path: 'project/src',
+          type: 'folder',
+          children: [
+            {
+              name: 'index',
+              path: 'project/src/index',
+              type: 'folder',
+              children: [
+                {
+                  name: 'test.txt',
+                  path: 'project/src/index/test.txt',
+                  type: 'file',
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'tests',
+              path: 'project/src/tests',
+              type: 'folder',
+              children: [
+                {
+                  name: 'test.js',
+                  path: 'project/src/tests/test.js',
+                  type: 'file',
+                  children: [],
+                },
+                {
+                  name: 'test2.ts',
+                  path: 'project/src/tests/test2.ts',
+                  type: 'file',
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'index.js',
+              path: 'project/src/index.js',
+              type: 'file',
+              children: [],
+            },
+          ],
+        },
+      ],
+    }
+    expect(parseToFileTree(files, 1)).toEqual(tree)
+  })
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,6 +15,13 @@ export interface RepoStateQueryResult {
   }
 }
 
+export interface FileTree {
+  name: string
+  path: string
+  type: 'folder' | 'file' | 'root'
+  children: FileTree[]
+}
+
 export interface Error {
   message: string
 }

--- a/frontend/src/utils/files.ts
+++ b/frontend/src/utils/files.ts
@@ -1,0 +1,52 @@
+import { File, FileTree } from '../types'
+
+export const parseToFileTree = (files: File[], rootOffset: number = 2) => {
+  if (files.length === 0) {
+    return undefined
+  }
+  const rootName = files[0].name.split('/').slice(0, rootOffset).join('/')
+  const root: FileTree = {
+    name: rootName,
+    path: rootName,
+    type: 'root',
+    children: [],
+  }
+  files.forEach((file) => {
+    addToFileTree(root, file.name, rootOffset)
+  })
+  return root
+}
+
+export const addToFileTree = (
+  root: FileTree,
+  path: string,
+  rootOffset: number = 2
+) => {
+  const sections = path.split('/')
+  const maxDepth = sections.length
+  let parent = root
+  for (let i = rootOffset; i < maxDepth; i++) {
+    const section = sections[i]
+    const child = parent.children.find((e) => e.name === section)
+    if (child) {
+      parent = child
+    } else {
+      const newNode: FileTree = {
+        name: section,
+        path: sections.slice(0, i + 1).join('/'),
+        type: i === maxDepth - 1 ? 'file' : 'folder',
+        children: [],
+      }
+      parent.children = parent.children.concat(newNode).sort(comparator)
+      parent = newNode
+    }
+  }
+}
+
+const comparator = (a: FileTree, b: FileTree) => {
+  if (a.type !== b.type) {
+    return a.type === 'folder' ? -1 : 1
+  }
+  return a.name.localeCompare(b.name)
+}
+


### PR DESCRIPTION
Closes #163 

- Modified the layout by adding a sidebar and a header
- Changed the file listing to a tree
- Some refactoring

Originally I wanted to just send a tree structure from the backend but it turns out it's not really possible to query recursive objects  with unknown depth unless you bypass GraphQL type checking completely and just fetch a raw json object, which seems like a bad idea. So because of that the parsing is done in the frontend. The way the tree is built is kinda inefficient but I didn't want to work on it more right now since maybe we end up sending the tree from the backend anyway (with pagination or something).