### PR TITLE
Issue145 merge conflict modal

### DIFF
--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -52,7 +52,7 @@ const MonacoEditor = ({ content, filename }: Props) => {
     setDialogOpen(false)
   }
 
-  const handleDialogSubmit = (
+  const handleDialogSubmit = async (
     createNewBranch: boolean,
     newBranch: string,
     commitMessage: string
@@ -60,7 +60,7 @@ const MonacoEditor = ({ content, filename }: Props) => {
     if (valueGetter.current) {
       const branchName = createNewBranch ? newBranch : currentBranch
       try {
-        saveChanges({
+        await saveChanges({
           variables: {
             file: {
               name: filename,
@@ -73,10 +73,12 @@ const MonacoEditor = ({ content, filename }: Props) => {
         setDialogOpen(false)
         setDialogError(undefined)
       } catch (error) {
-        setDialogError({
-          title: 'Merge conflict',
-          message: 'Cannot push to selected branch. Create a new one.',
-        })
+        if (error.message === 'Merge conflict detected') {
+          setDialogError({
+            title: 'Merge conflict',
+            message: 'Cannot push to selected branch. Create a new one.',
+          })
+        }
       }
     }
   }

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -16,10 +16,18 @@ interface Getter {
   (): string
 }
 
+interface DialogError {
+  title: string
+  message: string
+}
+
 const MonacoEditor = ({ content, filename }: Props) => {
   const [dialogOpen, setDialogOpen] = useState(false)
   const branchState = useQuery<RepoStateQueryResult>(REPO_STATE)
   const currentBranch = branchState.data?.repoState.currentBranch || ''
+  const [dialogError, setDialogError] = useState<DialogError | undefined>(
+    undefined
+  )
 
   const {
     loading: userQueryLoading,
@@ -51,20 +59,26 @@ const MonacoEditor = ({ content, filename }: Props) => {
   ) => {
     if (valueGetter.current) {
       const branchName = createNewBranch ? newBranch : currentBranch
-      saveChanges({
-        variables: {
-          file: {
-            name: filename,
-            content: valueGetter.current(),
+      try {
+        saveChanges({
+          variables: {
+            file: {
+              name: filename,
+              content: valueGetter.current(),
+            },
+            branch: branchName,
+            commitMessage: commitMessage,
           },
-          branch: branchName,
-          commitMessage: commitMessage,
-        },
-      }).catch((error: Error) => {
-        console.log(error.message)
-      })
+        })
+        setDialogOpen(false)
+        setDialogError(undefined)
+      } catch (error) {
+        setDialogError({
+          title: 'Merge conflict',
+          message: 'Cannot push to selected branch. Create a new one.',
+        })
+      }
     }
-    setDialogOpen(false)
   }
 
   const handleSaveButton = () => {
@@ -85,6 +99,7 @@ const MonacoEditor = ({ content, filename }: Props) => {
           handleClose={handleDialogClose}
           handleSubmit={handleDialogSubmit}
           currentBranch={currentBranch}
+          error={dialogError}
         />
         <Button
           color="primary"

--- a/frontend/src/components/SaveDialog.tsx
+++ b/frontend/src/components/SaveDialog.tsx
@@ -15,11 +15,18 @@ import {
   RadioGroup,
   TextField,
 } from '@material-ui/core'
+import { Alert, AlertTitle } from '@material-ui/lab'
+
+interface Error {
+  title: string
+  message: string
+}
 
 interface Props {
   open: boolean
   handleClose: () => void
   handleSubmit: (newBranch: boolean, name: string, message: string) => void
+  error: Error | undefined
   currentBranch: string
 }
 
@@ -28,6 +35,7 @@ const SaveDialog = ({
   handleClose,
   handleSubmit,
   currentBranch,
+  error,
 }: Props) => {
   const [createNewBranch, setCreateNewBranch] = useState(false)
   const [branchName, setBranchName] = useState('')
@@ -47,6 +55,13 @@ const SaveDialog = ({
       aria-labelledby="form-dialog-title"
     >
       <DialogTitle id="form-dialog-title">Save changes</DialogTitle>
+      {error && (
+        <Alert severity="error">
+          <AlertTitle>{error.title}</AlertTitle>
+          {error.message}
+        </Alert>
+      )}
+
       <DialogContent>
         <Grid container direction="column">
           <Grid item>
@@ -59,11 +74,17 @@ const SaveDialog = ({
                   setCreateNewBranch(event.target.value === 'true')
                 }
               >
-                <FormControlLabel
-                  value={false}
-                  control={<Radio color="primary" />}
-                  label={`Current: ${currentBranch}`}
-                />
+                {
+                  <FormControlLabel
+                    style={{
+                      display:
+                        error?.title === 'Merge conflict' ? 'none' : 'visible',
+                    }}
+                    value={false}
+                    control={<Radio color="primary" />}
+                    label={`Current: ${currentBranch}`}
+                  />
+                }
                 <FormControlLabel
                   value={true}
                   control={<Radio color="primary" />}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37513417/98685841-8cc59380-2370-11eb-87b3-46d8a28e358a.png)


closes #145 

If backend return "Merge conflict error" the push to current branch -option is hided and error message is shown to user. The error message persists until user  saves to new branch
