### PR TITLE
Issue172 postgres for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Web application to edit Robot Framework files remotely
     2. `cd frontend/ && yarn`
 3. Run `sudo docker-compose build`
 4. Run `sudo docker-compose up`
+     1. If database migrations seem to fail at start, run `sudo docker-compose up` again or `sudo docker-compose down --volumes` & `sudo docker-compose up`
 5. The application should be viewable in `localhost:3000`
 
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   application:
     image: ''
+    restart: always
     command: sh -c "yarn run migrate-up-prod && yarn start"
     stdin_open: true
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,37 @@
+version: '2.1'
+
+services:
+  testbackend:
+    command: sh -c "yarn run migrate-up-prod && yarn test"
+    build: ./backend
+    stdin_open: true
+    volumes:
+      - ./backend/:/usr/src/app
+      - ./backend/node_modules:/usr/src/app/node_modules
+    ports:
+      - '3001:3001'
+    environment:
+      - DATABASE_URL=postgres://test:test@testdata:5431/test
+    depends_on:
+      testdata:
+        condition: service_healthy
+
+  testdata:
+    image: 'postgres'
+    command: -p 5431
+    environment:
+      - POSTGRES_USER=test
+      - POSTGRES_DB=test
+      - POSTGRES_PASSWORD=test
+    volumes:
+      - testdata-data:/var/lib/postgresql/data/
+    ports:
+      - '5431:5431'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U test -p 5431 -d test']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  testdata-data:

--- a/documentation/backend.md
+++ b/documentation/backend.md
@@ -30,3 +30,12 @@
 ### GraphQL queries and mutations
 
 - Start the development version locally and open GraphQL docs in `localhost:PORT/graphql`
+
+### Testing 
+
+Run:
+1. `sudo docker-compose -f docker-compose.test.yml build`
+2. `sudo docker-compose -f docker-compose.test.yml up`
+
+Delete test postgres volumes if something doesn't seem to work:
+1. `sudo docker-compose -f docker-compose.test.yml down --volumes`


### PR DESCRIPTION
closes #172 

* Created `docker-compose.test.yml` to start postgresql and run backend tests
  * Version 2.1 of `docker-compose` had to be used for `healthcheck` condition. This now works for testing but we might want to think of better solutions for other `docker-compose` -files (dev and server). Added `restart: always` to our server `docker-compose` so it would restart if applications errors before postgres is up (this was already done on server). 