### PR TITLE
Add branch switching to backend

### DIFF
--- a/backend/src/schema/repository.ts
+++ b/backend/src/schema/repository.ts
@@ -5,13 +5,14 @@ import {
   pullMasterChanges,
   saveChanges,
   getBranches,
+  switchCurrentBranch,
 } from '../services/git'
 import { existsSync, readFileSync } from 'fs'
 import readRecursive from 'recursive-readdir'
 import { ForbiddenError } from 'apollo-server'
 import { relative } from 'path'
 import { AppContext } from '../types/user'
-import { SaveArgs } from '../types/params'
+import { BranchSwitchArgs, SaveArgs } from '../types/params'
 import { RepoState } from '../types/repoState'
 
 const typeDef = `
@@ -91,6 +92,16 @@ const resolvers = {
       }
 
       return 'Saved'
+    },
+    switchBranch: async (
+      _root: unknown,
+      branchSwitchArgs: BranchSwitchArgs,
+      _context: unknown
+    ): Promise<string> => {
+      const url = new URL(branchSwitchArgs.url)
+      const repositoryName = url.pathname
+      const repoLocation = `./repositories/${repositoryName}`
+      return await switchCurrentBranch(repoLocation, branchSwitchArgs.branch)
     },
   },
 }

--- a/backend/src/schema/schema.ts
+++ b/backend/src/schema/schema.ts
@@ -36,6 +36,10 @@ const Mutation = `
         authorizeWithGithub(
             code: String!
         ): AuthResponse
+        switchBranch(
+            url: String!
+            branch: String!
+        ): String
     }
 `
 

--- a/backend/src/services/git.ts
+++ b/backend/src/services/git.ts
@@ -15,6 +15,14 @@ export const getCurrentBranchName = async (
   return branches.current
 }
 
+export const switchCurrentBranch = async (
+  repoLocation: string,
+  branchName: string
+): Promise<string> => {
+  const git = simpleGit(repoLocation)
+  return await gitCheckout(git, branchName)
+}
+
 export const pullMasterChanges = async (httpsURL: string): Promise<void> => {
   const url = new URL(httpsURL)
   const repositoryName = url.pathname
@@ -84,10 +92,10 @@ const gitCheckout = async (git: SimpleGit, branchName: string) => {
 
   if (await branchExists(git, sanitizedBranchName)) {
     await git.checkout([sanitizedBranchName])
-    return
+  } else {
+    await git.checkout(['-b', sanitizedBranchName])
   }
-
-  await git.checkout(['-b', sanitizedBranchName])
+  return sanitizedBranchName
 }
 
 const branchExists = async (

--- a/backend/src/types/params.ts
+++ b/backend/src/types/params.ts
@@ -1,7 +1,12 @@
 import { File } from './file'
 
 export interface SaveArgs {
-    file: File,
-    branch: string,
-    commitMessage: string,
+  file: File
+  branch: string
+  commitMessage: string
+}
+
+export interface BranchSwitchArgs {
+  url: string
+  branch: string
 }


### PR DESCRIPTION
Closes #169 (I guess?)

- Added backend mutation for switching current branch.
    - The mutation takes in the url of the repo and the name of the branch
    - Returns back the name of the branch
    - This is a quick and temporary solution until DB is ready to store user specific repo state. Mainly did this to define our API so #148 has something to call.
- No tests because the logic will change anyway