### PR TITLE
Make git reset local changes before pulling to fix bug

### DIFF
--- a/backend/src/schema/repository.ts
+++ b/backend/src/schema/repository.ts
@@ -2,7 +2,7 @@
 import {
   cloneRepository,
   getCurrentBranchName,
-  pullMasterChanges,
+  pullCurrentBranchChanges,
   saveChanges,
   getBranches,
   switchCurrentBranch,
@@ -45,7 +45,7 @@ const resolvers = {
       if (!existsSync(fileLocation)) {
         await cloneRepository(url.href)
       } else {
-        await pullMasterChanges(url.href)
+        await pullCurrentBranchChanges(url.href)
       }
       return 'Cloned'
     },

--- a/backend/src/services/git.ts
+++ b/backend/src/services/git.ts
@@ -23,13 +23,19 @@ export const switchCurrentBranch = async (
   return await gitCheckout(git, branchName)
 }
 
-export const pullMasterChanges = async (httpsURL: string): Promise<void> => {
+export const pullCurrentBranchChanges = async (
+  httpsURL: string
+): Promise<void> => {
   const url = new URL(httpsURL)
   const repositoryName = url.pathname
 
-  await simpleGit(`./repositories/${repositoryName}`)
+  const git = simpleGit(`./repositories/${repositoryName}`)
+  const currentlyActiveBranch = (await git.branch()).current
+
+  await git
     .fetch('origin')
-    .pull('origin', 'master')
+    .reset(['--hard'])
+    .pull('origin', currentlyActiveBranch)
 }
 
 export const cloneRepository = async (httpsURL: string): Promise<void> => {


### PR DESCRIPTION
closes #176 

- Local git had untracked files after pushing to new branch. Error messages that caused the "error cloning repo" to frontend were "unmerged paths"-error and another one similar to "The following untracked working tree files would be overwritten by checkout". 
- Made a simple workaround to this by resetting local changes so already pushed changes could be pulled from remote without conflicts.