### PR TITLE
Fix backend error after merge conflict

### DIFF
--- a/backend/src/schema/repository.ts
+++ b/backend/src/schema/repository.ts
@@ -2,7 +2,7 @@
 import {
   cloneRepository,
   getCurrentBranchName,
-  pullMasterChanges,
+  pullNewestChanges,
   saveChanges,
   getBranches,
   switchCurrentBranch,
@@ -45,7 +45,7 @@ const resolvers = {
       if (!existsSync(fileLocation)) {
         await cloneRepository(url.href)
       } else {
-        await pullMasterChanges(url.href)
+        await pullNewestChanges(url.href)
       }
       return 'Cloned'
     },

--- a/backend/src/services/git.ts
+++ b/backend/src/services/git.ts
@@ -23,13 +23,20 @@ export const switchCurrentBranch = async (
   return await gitCheckout(git, branchName)
 }
 
-export const pullMasterChanges = async (httpsURL: string): Promise<void> => {
+export const pullNewestChanges = async (httpsURL: string): Promise<void> => {
   const url = new URL(httpsURL)
   const repositoryName = url.pathname
+  const repoLocation = `./repositories/${repositoryName}`
+
+  const currentBranch = await getCurrentBranch(repoLocation)
 
   await simpleGit(`./repositories/${repositoryName}`)
     .fetch('origin')
-    .pull('origin', 'master')
+    .branch([`--set-upstream-to=origin/${currentBranch}`, currentBranch])
+    .pull()
+    .catch((error: GitError) => {
+      console.log(error)
+    })
 }
 
 export const cloneRepository = async (httpsURL: string): Promise<void> => {
@@ -190,4 +197,12 @@ export const getBranches = async (repoLocation: string): Promise<string[]> => {
   const git = simpleGit(repoLocation)
   const branches = await git.branch()
   return branches.all
+}
+
+export const getCurrentBranch = async (
+  repoLocation: string
+): Promise<string> => {
+  const git = simpleGit(repoLocation)
+  const branches = await git.branchLocal()
+  return branches.current
 }


### PR DESCRIPTION
closes #176 

The application tried to pull newest changes to `master` which caused a crash after a merge conflict. Here's a quick fix for this problem. I don't know how to test git pulling from remote so now there's no tests for this bug. I will open a refactoring issue after this to start working on making the structure of repository actions a bit more testable and write tests for various situations in there. 