### PR TITLE
Issue189 return only token

### DIFF
--- a/backend/src/schema/schema.ts
+++ b/backend/src/schema/schema.ts
@@ -13,10 +13,6 @@ const Query = `
 `
 
 const Mutation = `
-    type AuthResponse {
-        user: User
-        token: String
-    }
     type ServiceAuthResponse {
         serviceUser: ServiceUser
         token: String
@@ -42,11 +38,11 @@ const Mutation = `
             username: String!
             email: String!
             password: String!
-        ): AuthResponse
+        ): String
         login(
             username: String!
             password: String!
-        ): AuthResponse
+        ): String
         saveChanges(
             file: FileInput! 
             branch: String!

--- a/backend/src/schema/user.ts
+++ b/backend/src/schema/user.ts
@@ -46,13 +46,13 @@ const resolvers = {
     },
     githubLoginUrl: (): string => {
       const cbUrl = config.GITHUB_CB_URL || ''
-      const cliendID = config.GITHUB_CLIENT_ID || ''
+      const clientID = config.GITHUB_CLIENT_ID || ''
 
-      if (!cbUrl || !cliendID) {
-        throw new Error('GitHub cliend id or callback url not set')
+      if (!cbUrl || !clientID) {
+        throw new Error('GitHub client id or callback url not set')
       }
 
-      return `https://github.com/login/oauth/authorize?response_type=code&redirect_uri=${cbUrl}&client_id=${cliendID}`
+      return `https://github.com/login/oauth/authorize?response_type=code&redirect_uri=${cbUrl}&client_id=${clientID}`
     },
     currentToken: (
       _root: unknown,

--- a/backend/src/schema/user.ts
+++ b/backend/src/schema/user.ts
@@ -3,7 +3,6 @@ import bcrypt from 'bcryptjs'
 import config from '../utils/config'
 import {
   UserType,
-  AuthResponse,
   AppContext,
   GitHubAuthCode,
   ServiceAuthResponse,
@@ -138,7 +137,7 @@ const resolvers = {
     register: async (
       _root: unknown,
       args: RegisterUserInput
-    ): Promise<AuthResponse> => {
+    ): Promise<string> => {
       if (
         args.username.length === 0 ||
         args.email.length === 0 ||
@@ -157,15 +156,12 @@ const resolvers = {
 
       const token = createToken(user)
 
-      return {
-        user,
-        token,
-      }
+      return token
     },
     login: async (
       _root: unknown,
       args: LoginUserInput
-    ): Promise<AuthResponse> => {
+    ): Promise<string> => {
       const user = await User.findUserByUsername(args.username)
 
       if (!user) {
@@ -183,10 +179,7 @@ const resolvers = {
 
       const token = createToken(user)
 
-      return {
-        user,
-        token,
-      }
+      return token
     },
   },
 }

--- a/backend/src/tests/userschema.test.ts
+++ b/backend/src/tests/userschema.test.ts
@@ -172,8 +172,13 @@ describe('User schema login mutations', () => {
       },
     })
 
+    const expectedUser = await User.findUserByUsername('testuser')
+    const expectedToken = createToken(expectedUser)
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(res.data?.login).toBeTruthy()
+    expect(res.data).toEqual({
+      login: expectedToken
+    })
   })
 
   it('user can not login without username and password', async () => {

--- a/backend/src/tests/userschema.test.ts
+++ b/backend/src/tests/userschema.test.ts
@@ -40,10 +40,6 @@ const REGISTER = gql`
   mutation register($username: String!, $email: String!, $password: String!) {
     register(username: $username, email: $email, password: $password) {
       token
-      user {
-        id
-        username
-      }
     }
   }
 `
@@ -52,10 +48,6 @@ const LOGIN = gql`
   mutation login($username: String!, $password: String!) {
     login(username: $username, password: $password) {
       token
-      user {
-        id
-        username
-      }
     }
   }
 `
@@ -82,11 +74,7 @@ describe('User schema register mutations', () => {
     expect(mutationResult).toEqual({
       data: {
         register: {
-          token: expectedToken,
-          user: {
-            id: expectedUser?.id,
-            username: expectedUser?.username,
-          },
+          token: expectedToken
         },
       },
     })
@@ -191,7 +179,7 @@ describe('User schema login mutations', () => {
     })
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(res.data?.login?.user?.username).toEqual('testuser')
+    expect(res.data?.login?.token).toBeTruthy()
   })
 
   it('user can not login without username and password', async () => {

--- a/backend/src/tests/userschema.test.ts
+++ b/backend/src/tests/userschema.test.ts
@@ -38,17 +38,13 @@ const GH_TOKEN = gql`
 
 const REGISTER = gql`
   mutation register($username: String!, $email: String!, $password: String!) {
-    register(username: $username, email: $email, password: $password) {
-      token
-    }
+    register(username: $username, email: $email, password: $password)
   }
 `
 
 const LOGIN = gql`
   mutation login($username: String!, $password: String!) {
-    login(username: $username, password: $password) {
-      token
-    }
+    login(username: $username, password: $password)
   }
 `
 
@@ -73,9 +69,7 @@ describe('User schema register mutations', () => {
 
     expect(mutationResult).toEqual({
       data: {
-        register: {
-          token: expectedToken
-        },
+        register: expectedToken
       },
     })
   })
@@ -92,7 +86,7 @@ describe('User schema register mutations', () => {
       },
     })
 
-    expect(res.data?.register?.token).toBeTruthy()
+    expect(res.data?.register).toBeTruthy()
   })
 
   it('user can not register without a username', async () => {
@@ -179,7 +173,7 @@ describe('User schema login mutations', () => {
     })
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(res.data?.login?.token).toBeTruthy()
+    expect(res.data?.login).toBeTruthy()
   })
 
   it('user can not login without username and password', async () => {

--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -25,11 +25,6 @@ export interface UserType {
   services?: ServiceUserType[]
 }
 
-export interface AuthResponse {
-  user: UserType
-  token: string
-}
-
 export interface ServiceAuthResponse {
   serviceUser: ServiceUserType
   token: string

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -26,9 +26,7 @@ export const SAVE_CHANGES = gql`
 
 export const REGISTER = gql`
   mutation register($username: String!, $email: String!, $password: String!) {
-    register(username: $username, email: $email, password: $password) {
-      token
-    }
+    register(username: $username, email: $email, password: $password)
   }
 `
 

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -23,14 +23,10 @@ export const SAVE_CHANGES = gql`
     saveChanges(file: $file, branch: $branch, commitMessage: $commitMessage)
   }
 `
+
 export const REGISTER = gql`
   mutation register($username: String!, $email: String!, $password: String!) {
     register(username: $username, email: $email, password: $password) {
-      user {
-        id
-        username
-        email
-      }
       token
     }
   }


### PR DESCRIPTION
Closes #189 

Changed the backend mutations register and login to return only token, because currentUser is stored in apollo context and returning the user would have no effect. Changed also related tests and frontend register mutation.